### PR TITLE
360提供的Google公共库停止服务，切换回Google官方URL

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -29,7 +29,7 @@
     <link rel="icon" href="<%- theme.favicon %>">
   <% } %>
   <% if (config.highlight.enable){ %>
-    <link href="//fonts.useso.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
   <% } %>
   <%- css('css/style') %>
   <%- partial('google-analytics') %>


### PR DESCRIPTION
360提供的Google公共库自2016-8-31停止服务，Source+Code+Pro加载不出，超时，详见公告：wangzhan.360.com/notice/detail4。

解决办法是切换回Google的官网URL，Google已经在国内部署了镜像了，速度可以接受。